### PR TITLE
Verify tei attribute serialization.

### DIFF
--- a/test/test_tei.py
+++ b/test/test_tei.py
@@ -6,27 +6,38 @@ import tei
 
 
 def qualify(path):
-    '''Expand each element in an XPath into a qname'''
+    '''Expand each element in an XPath into a qname.'''
     result = []
-    for tag in path.split():
+    for tag in path.split('/'):
         qname = '{' + tei.namespace + '}' + tag
         result.append(qname)
-    return ' '.join(result)
+    return '/'.join(result)
 
 
 def test_bare():
+    'Verify a bare document has a body element.'
     doc = tei.Document()
     xml = ET.fromstring(str(doc))
     assert xml.tag == qualify('TEI')
+    assert len(xml.findall(qualify('text/body'))) == 1
 
 
 def test_title():
+    'Verify a base header has a title element.'
     header = tei.Header()
     xml = ET.fromstring(str(header))
     assert xml.tag == 'teiHeader'
+    fileDesc = xml[0]
+    assert fileDesc.tag == 'fileDesc'
+    title = fileDesc[0][0]
+    assert title.tag == 'title'
+    # Header doesn't set a namespace attribute so no need to qualify.
+    title = xml.find('fileDesc/titleStmt/title')
+    assert title.tag == 'title'
 
 
 def test_document():
+    'Verify basic attributes of a document are serialized.'
     name = 'Example Text Document'
     doc = tei.Document()
     doc.header = tei.Header()
@@ -38,3 +49,8 @@ def test_document():
     doc.parts.append(translation)
     xml = ET.fromstring(str(doc))
     assert xml.tag == qualify('TEI')
+    title = xml.find(qualify('teiHeader/fileDesc/titleStmt/title'))
+    assert title.text == name
+    divs = xml.findall(qualify('text/body/div'))
+    assert divs[0].attrib['type'] == 'edition'
+    assert divs[1].attrib['type'] == 'translation'


### PR DESCRIPTION
Fix issues with the xml serialization class tests.

A Document sets an xml namespace attribute, but a bare
Header does not. That may be incorrect, but it means
we need to namespace-qualify xpath queries when traversing
a Document, but not an unattached Header.

Also, xpath queries are separated by '/' not whitespace!