### PR TITLE
Update travis badge to use cdli-gh fork.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # atf2tei
 
-[![Build Status](https://travis-ci.org/rillian/atf2tei.svg?branch=master)](https://travis-ci.org/rillian/atf2tei)
+[![Build Status](https://travis-ci.org/cdli-gh/atf2tei.svg?branch=master)](https://travis-ci.org/cdli-gh/atf2tei)
 
 This is a tool for converting [ATF](http://oracc.museum.upenn.edu/doc/help/editinginatf/),
 a text markup format used by the [Cuneiform Digital Library Initiative](https://cdli.ucla.edu)


### PR DESCRIPTION
Now that upstream is the cdli-gh repository, its status is the
more appropriate one to advertise.

r? @willismonroe