### PR TITLE
Improve CTS compliance

### DIFF
--- a/atf2cts.py
+++ b/atf2cts.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from xml.dom.minidom import parseString
+
 import atf2tei
 import cts
 
@@ -28,18 +30,18 @@ def convert(atf, data_path):
     success = 0
 
     try:
-        xml = atf2tei.convert(atf)
+        doc = atf2tei.convert(atf)
     except Exception as e:
         print('Error converting ATF:', e)
         print(atf)
         failed_parse.append(atf)
         return (success, failed_parse, failed_export)
     try:
-        dom = parseString(xml)
+        dom = parseString(str(doc))
     except Exception as e:
         print('Error parsing converted XML:', e)
-        print(xml)
-        failed_export.append(xml)
+        print(doc)
+        failed_export.append(doc)
         return (success, failed_parse, failed_export)
     texts = dom.getElementsByTagName('text')
     assert len(texts) == 1
@@ -70,7 +72,7 @@ def convert(atf, data_path):
         f.write(str(work))
 
     with io.open(doc_filename, encoding='utf-8', mode='w') as f:
-        f.write(xml)
+        f.write(str(doc))
     success += 1
 
     return (success, failed_parse, failed_export)
@@ -83,7 +85,6 @@ if __name__ == '__main__':
 
     from concurrent import futures
     from datetime import datetime
-    from xml.dom.minidom import parseString
 
     start = datetime.utcnow()
     failed_parse = []

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -70,7 +70,7 @@ def convert(atf, textgroup, data_path):
                  mode='w') as f:
         f.write(str(work))
 
-    doc_filename = urn.split(':')[-1] + '.xml'
+    doc_filename = urn.split(':')[-1] + '.' + doc.language + '.xml'
     doc_path = os.path.join(work_path, doc_filename)
     with io.open(doc_path, encoding='utf-8', mode='w') as f:
         f.write(str(doc))

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -5,6 +5,7 @@ from xml.dom.minidom import parseString
 
 import atf2tei
 import cts
+import tei
 
 
 def segmentor(fp):
@@ -56,11 +57,6 @@ def convert(atf, textgroup, data_path):
     work.label = f'CDLI {doc.header.cdli_code} {work.title}'
     work.description = 'Test doc converted from atf.'
 
-    # Add CTS refsDecl.
-    encodingDesc = ET.Element('encodingDesc')
-    encodingDesc.append(cts.RefsDecl().xml)
-    doc.header.encodingDesc = encodingDesc
-
     work_path = os.path.join(data_path, urn.split('.')[-1])
 
     print('Writing', urn, doc.language, 'to', work_path)
@@ -69,6 +65,17 @@ def convert(atf, textgroup, data_path):
                  encoding='utf-8',
                  mode='w') as f:
         f.write(str(work))
+
+    # Set Edition urn per CTS epidoc guidelines.
+    for obj in doc.parts:
+        if isinstance(obj, tei.Edition):
+            obj.name = urn
+            obj.language = work.language
+
+    # Add CTS refsDecl.
+    encodingDesc = ET.Element('encodingDesc')
+    encodingDesc.append(cts.RefsDecl().xml)
+    doc.header.encodingDesc = encodingDesc
 
     doc_filename = urn.split(':')[-1] + '.' + doc.language + '.xml'
     doc_path = os.path.join(work_path, doc_filename)

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -43,19 +43,13 @@ def convert(atf, data_path):
         print('Error parsing converted XML:', e)
         print(doc)
         return export_failed
-    texts = dom.getElementsByTagName('text')
-    assert len(texts) == 1
-    text = texts[0]
-    urn = text.getAttribute('n')
-    lang = text.getAttribute('xml:lang')
-    title = dom.getElementsByTagName('title')[0].firstChild.data
 
-    doc_basename = urn.split(':')[-1]
-    doc_dirname = doc_basename.split('.')[-1]
-    doc_path = os.path.join(data_path, doc_dirname)
-    doc_filename = os.path.join(
-            doc_path, doc_basename + '.' + lang + '.xml')
-    print('Writing', urn, lang, 'to', doc_filename)
+    # Fetch title
+    urn = f'urn:cts:cdli:test.{doc.header.cdli_code}'
+    doc.groupUrn = urn
+
+    group_filename = groupUrn.split(':')[-1]
+    group_path = os.path.join(data_path, group_dirname)
 
     work = cts.Work()
     work.group_urn = textgroup.urn
@@ -65,13 +59,16 @@ def convert(atf, data_path):
     work.label = ' '.join(['CDLI', doc_dirname, title])
     work.title = title
 
+    doc_filename = urn.split(':')[-1] + '.xml'
+    doc_path = os.path.join(group_path, doc_filename)
+    print('Writing', urn, doc.language, 'to', doc_filename)
     os.makedirs(doc_path, exist_ok=True)
     with io.open(os.path.join(doc_path, '__cts__.xml'),
                  encoding='utf-8',
                  mode='w') as f:
         f.write(str(work))
 
-    with io.open(doc_filename, encoding='utf-8', mode='w') as f:
+    with io.open(doc_path, encoding='utf-8', mode='w') as f:
         f.write(str(doc))
 
     return success

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -67,9 +67,10 @@ def convert(atf, textgroup, data_path):
         f.write(str(work))
 
     # Set Edition urn per CTS epidoc guidelines.
+    editionUrn = f'{work.workUrn}.cdli-{work.language}'
     for obj in doc.parts:
         if isinstance(obj, tei.Edition):
-            obj.name = urn
+            obj.name = editionUrn
             obj.language = work.language
 
     # Add CTS refsDecl.
@@ -77,7 +78,7 @@ def convert(atf, textgroup, data_path):
     encodingDesc.append(cts.RefsDecl().xml)
     doc.header.encodingDesc = encodingDesc
 
-    doc_filename = urn.split(':')[-1] + '.' + doc.language + '.xml'
+    doc_filename = editionUrn.split(':')[-1] + '.xml'
     doc_path = os.path.join(work_path, doc_filename)
     with io.open(doc_path, encoding='utf-8', mode='w') as f:
         f.write(str(doc))

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import xml.etree.ElementTree as ET
 from xml.dom.minidom import parseString
 
 import atf2tei
@@ -54,6 +55,11 @@ def convert(atf, textgroup, data_path):
     work.title = doc.header.title
     work.label = f'CDLI {doc.header.cdli_code} {work.title}'
     work.description = 'Test doc converted from atf.'
+
+    # Add CTS refsDecl.
+    encodingDesc = ET.Element('encodingDesc')
+    encodingDesc.append(cts.RefsDecl().xml)
+    doc.header.encodingDesc = encodingDesc
 
     work_path = os.path.join(data_path, urn.split('.')[-1])
 

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -59,6 +59,7 @@ def convert(atf_text):
     objects = [item for item in atf.text.children
                if isinstance(item, OraccObject)]
     edition = tei.Edition()
+    doc.parts.append(edition)
     for item in objects:
         part = tei.TextPart(item.objecttype)
         edition.append(part)
@@ -99,7 +100,9 @@ def convert(atf_text):
                     continue
     objects = [item for item in atf.text.children
                if isinstance(item, OraccObject)]
-    translation = tei.Translation()
+    if objects:
+        translation = tei.Translation()
+        doc.parts.append(translation)
     for item in objects:
         part = tei.TextPart(item.objecttype)
         translation.append(part)
@@ -123,6 +126,7 @@ def convert(atf_text):
     for lang, tr_lines in translations.items():
         translation = tei.Translation()
         translation.language = lang
+        doc.parts.append(translation)
         for tr_line in tr_lines:
             text = ' '.join(tr_line.words)
             line = tei.Line(tr_line.label, text)
@@ -167,5 +171,5 @@ if __name__ == '__main__':
     import sys
     for filename in sys.argv[1:]:
         with io.open(filename, encoding='utf-8') as f:
-            xml = convert(f.read())
-            print(xml)
+            doc = convert(f.read())
+            print(doc)

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -156,13 +156,9 @@ def normalize_transliteration(words):
         'XML-escape the result.'
         word = escape(word)
         'Convert markup to tei elements.'
-        word = re.sub(r'{([^{}]+)}',
-                      r'<c type="determinative">\1</c>',
-                      word)
-        word = re.sub(r'_([\w<{([\|.]+)',
-                      r'<c type="sign" subtype="logo">\1',
-                      word)
-        word = re.sub(r'([\w)}>\|\.#\?]+)_', r'\1</c>', word)
+        # TODO: <c type="determinative">
+        # TODO: <c type="sign" subtype="logo">
+        # TODO: half-bracket for damage
         result.append(word)
     return ' '.join(result)
 

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -153,12 +153,18 @@ def normalize_transliteration(words):
         word = re.sub(r'H,', 'Ḫ', word)     # \u1E2A
         word = re.sub(r'j', 'ŋ', word)      # \u014B
         word = re.sub(r'J', 'Ŋ', word)      # \u014A
+        'Convert damage marks to half-brackets.'
+        marked = [
+            '⸢' + sign[:-1] + '⸣' if sign.endswith('#')
+            else sign
+            for sign in word.split('-')
+        ]
+        word = '-'.join(marked)
         'XML-escape the result.'
         word = escape(word)
         'Convert markup to tei elements.'
         # TODO: <c type="determinative">
         # TODO: <c type="sign" subtype="logo">
-        # TODO: half-bracket for damage
         result.append(word)
     return ' '.join(result)
 

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -32,7 +32,9 @@ def convert(atf_text):
     <p>Converted from ATF by atf2tei.</p>
   </publicationStmt>
   <sourceDesc>
-    <idno type="CDLI">{code}</idno>
+    <bibl>
+      <title>CDLI <idno type="CDLI">{code}</idno></title>
+    </bibl>
   </sourceDesc>
 </fileDesc>
 <encodingDesc>

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -69,7 +69,7 @@ def convert(atf_text):
     translations = {}
     objects = [item for item in atf.text.children
                if isinstance(item, OraccObject)]
-    result += '''  <div type="edition">\n'''
+    result += '  <div type="edition">\n'
     for item in objects:
         result += f'  <div type="textpart" n="{item.objecttype}">\n'
         for section in item.children:
@@ -144,11 +144,11 @@ def convert(atf_text):
 
 
 def normalize_transliteration(words):
-    '''Convert a sequence of words from atf to standard formatting.'''
+    'Convert a sequence of words from atf to standard formatting.'
     # See http://oracc.org/doc/help/editinginatf/primer/inlinetutorial/
     result = []
     for word in words:
-        '''Convert digraphs to corresponding unicode characters.'''
+        'Convert digraphs to corresponding unicode characters.'
         word = re.sub(r'sz', 'š', word)     # \u0161
         word = re.sub(r'SZ', 'Š', word)     # \u0160
         word = re.sub(r's,', 'ṣ', word)     # \u1E63
@@ -161,9 +161,9 @@ def normalize_transliteration(words):
         word = re.sub(r'H,', 'Ḫ', word)     # \u1E2A
         word = re.sub(r'j', 'ŋ', word)      # \u014B
         word = re.sub(r'J', 'Ŋ', word)      # \u014A
-        '''XML-escape the result.'''
+        'XML-escape the result.'
         word = escape(word)
-        '''Convert markup to tei elements.'''
+        'Convert markup to tei elements.'
         word = re.sub(r'{([^{}]+)}',
                       r'<c type="determinative">\1</c>',
                       word)

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -23,6 +23,7 @@ def convert(atf_text):
     if verbose:
         print("Parsed {} -- {}".format(atf.text.code, atf.text.description))
     doc = tei.Document()
+    doc.language = atf.text.language
     doc.header = tei.Header()
     doc.header.title = atf.text.description
     doc.header.cdli_code = atf.text.code

--- a/cts.py
+++ b/cts.py
@@ -39,12 +39,12 @@ class Work:
     ns = {'ti': 'http://chs.harvard.edu/xmlns/cts'}
 
     def __init__(self):
-        self.group_urn = None
-        self.work_urn = None
+        self.groupUrn = None
+        self.workUrn = None
         self.language = None
-        self.description = None
-        self.label = None
         self.title = None
+        self.label = None
+        self.description = None
 
     def __str__(self):
         'Serialized XML representation as a string.'

--- a/cts.py
+++ b/cts.py
@@ -1,10 +1,11 @@
 '''Models for generating Canonical Text Services index files.'''
 
 import xml.etree.ElementTree as ET
-from xml.dom.minidom import parseString
+
+from tei import XMLSerializer
 
 
-class TextGroup:
+class TextGroup(XMLSerializer):
     '''Represents a textgroup element.'''
 
     ns = {'ti': 'http://chs.harvard.edu/xmlns/cts'}
@@ -12,11 +13,6 @@ class TextGroup:
     def __init__(self):
         self.urn = None
         self.name = None
-
-    def __str__(self):
-        'Serialized XML representation as a string.'
-        serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
 
     @property
     def xml(self):
@@ -33,7 +29,7 @@ class TextGroup:
         return xml
 
 
-class Work:
+class Work(XMLSerializer):
     '''Represents a TEI work.'''
 
     ns = {'ti': 'http://chs.harvard.edu/xmlns/cts'}
@@ -45,11 +41,6 @@ class Work:
         self.title = None
         self.label = None
         self.description = None
-
-    def __str__(self):
-        'Serialized XML representation as a string.'
-        serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
 
     @property
     def xml(self):

--- a/cts.py
+++ b/cts.py
@@ -75,13 +75,23 @@ class RefsDecl(XMLSerializer):
 
     Results are specific to the way we structure cuneiform
     data from ATF.'''
+    prefix = '#xpath(/tei:TEI/tei:text/tei:body/tei:div'
     levels = [
-        ('line', 3,
-            'This pattern references a specific line.'),
-        ('surface', 2,
-            'This pattern references an inscribed surface.'),
-        ('object', 1,
-            'This pattern references a specific artefact, usually a tablet.'),
+        (
+          'line', 3,
+          'This pattern references a specific line.',
+          prefix + "/tei:div[@n='$1']/tei:div[@n='$2']/tei:l[@n='$3'])"
+        ),
+        (
+          'surface', 2,
+          'This pattern references an inscribed surface.',
+          prefix + "/tei:div[@n='$1']/tei:div[@n='$2'])"
+        ),
+        (
+          'object', 1,
+          'This pattern references a specific artefact, usually a tablet.',
+          prefix + "/tei:div[@n='$1'])"
+        ),
     ]
 
     @property
@@ -89,14 +99,10 @@ class RefsDecl(XMLSerializer):
         'Construct an XML ElementTree representation of member data.'
         refsDecl = ET.Element('refsDecl')
         refsDecl.set('n', 'CTS')
-        for name, count, description in self.levels:
+        for name, count, description, xpath in self.levels:
             pattern = ET.SubElement(refsDecl, 'cRefPattern')
             pattern.set('n', name)
             pattern.set('matchPattern', r'\.'.join([r'(\w+)'] * count))
-            xpath = '#xpath(/tei:TEI/tei:text/tei:body/tei:div'
-            for i in range(count):
-                xpath += f"/tei:div[@n='${i + 1}']"
-            xpath += ')'
             pattern.set('replacementPattern', xpath)
             p = ET.SubElement(pattern, 'p')
             p.text = description

--- a/cts.py
+++ b/cts.py
@@ -62,12 +62,12 @@ class Work:
         title.text = self.title
         title.set('xml:lang', 'eng')
         edition = ET.SubElement(xml, 'ti:edition')
-        if self.group_urn:
-            xml.set('groupUrn', self.group_urn)
-        if self.work_urn:
-            xml.set('urn', self.work_urn)
-            edition.set('workUrn', self.work_urn)
-            edition.set('urn', self.work_urn + '.' + self.language)
+        if self.groupUrn:
+            xml.set('groupUrn', self.groupUrn)
+        if self.workUrn:
+            xml.set('urn', self.workUrn)
+            edition.set('workUrn', self.workUrn)
+            edition.set('urn', self.workUrn + '.' + self.language)
         label = ET.SubElement(edition, 'ti:label')
         if self.label:
             label.text = self.label

--- a/tei.py
+++ b/tei.py
@@ -81,6 +81,10 @@ class TextPart:
         serialized = ET.tostring(self.xml, encoding='unicode')
         return parseString(serialized).toprettyxml()
 
+    def append(self, obj):
+        'Append a sub-element to the list of children.'
+        self.children.append(obj)
+
     @property
     def xml(self):
         'Construct an XML ElementTree representation.'

--- a/tei.py
+++ b/tei.py
@@ -28,7 +28,6 @@ class Document(XMLSerializer):
         self.header = None
         self.parts = []
         self.language = None
-        self.urn = None
 
     @property
     def xml(self):
@@ -39,11 +38,6 @@ class Document(XMLSerializer):
             xml.append(self.header.xml)
         text = ET.SubElement(xml, 'text')
         body = ET.SubElement(text, 'body')
-        # General TEI style has CTS urn and language on the body tag.
-        if self.urn:
-            body.set('n', self.urn)
-        if self.language:
-            body.set('xml:lang', self.language)
         for part in self.parts:
             body.append(part.xml)
         return xml

--- a/tei.py
+++ b/tei.py
@@ -37,6 +37,8 @@ class Header:
 
     def __init__(self):
         self.title = None
+        self.publication = 'Converted from ATF by atf2tei.'
+        self.cdli_code = None
 
     def __str__(self):
         'Serialized XML representation as a string.'
@@ -51,6 +53,18 @@ class Header:
         titleStmt = ET.SubElement(fileDesc, 'titleStmt')
         title = ET.SubElement(titleStmt, 'title')
         title.text = self.title
+        if self.publication:
+            publicationStmt = ET.SubElement(fileDesc, 'publicationStmt')
+            p = ET.SubElement(publicationStmt, 'p')
+            p.text = self.publication
+        if self.cdli_code:
+            sourceDesc = ET.SubElement(fileDesc, 'sourceDesc')
+            bibl = ET.SubElement(sourceDesc, 'bibl')
+            title = ET.SubElement(bibl, 'title')
+            title.text = 'CDLI'
+            idno = ET.SubElement(title, 'idno')
+            idno.set('type', 'CDLI')
+            idno.text = self.cdli_code
         return xml
 
 

--- a/tei.py
+++ b/tei.py
@@ -12,6 +12,7 @@ class Document:
     def __init__(self):
         self.header = None
         self.parts = []
+        self.language = None
 
     def __str__(self):
         'Serialized XML representation as a string.'

--- a/tei.py
+++ b/tei.py
@@ -71,8 +71,8 @@ class Header:
 class TextPart:
     '''Represents an Epidoc text division.'''
 
-    def __init__(self):
-        self.name = None
+    def __init__(self, name=None):
+        self.name = name
         self.type = 'textpart'
         self.children = []
 

--- a/tei.py
+++ b/tei.py
@@ -13,6 +13,7 @@ class Document:
         self.header = None
         self.parts = []
         self.language = None
+        self.urn = None
 
     def __str__(self):
         'Serialized XML representation as a string.'
@@ -28,6 +29,11 @@ class Document:
             xml.append(self.header.xml)
         text = ET.SubElement(xml, 'text')
         body = ET.SubElement(text, 'body')
+        # General TEI style has CTS urn and language on the body tag.
+        if self.urn:
+            body.set('n', self.urn)
+        if self.language:
+            body.set('xml:lang', self.language)
         for part in self.parts:
             body.append(part.xml)
         return xml

--- a/tei.py
+++ b/tei.py
@@ -17,7 +17,8 @@ class XMLSerializer:
     def __str__(self):
         'Serialized XML representation as a string.'
         serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
+        # Run the xml through minidom to control the indent.
+        return parseString(serialized).toprettyxml(indent='  ')
 
 
 class Document(XMLSerializer):

--- a/tei.py
+++ b/tei.py
@@ -76,11 +76,15 @@ class Header:
 
 
 class TextPart:
-    '''Represents an Epidoc text division.'''
+    '''Represents an Epidoc text division.
+
+    Set the name attribute to book, chapter, obverse, etc.,
+    whatever describes the division.'''
 
     def __init__(self, name=None):
         self.name = name
         self.type = 'textpart'
+        self.language = None
         self.children = []
 
     def __str__(self):
@@ -99,13 +103,17 @@ class TextPart:
         xml.set('type', self.type)
         if self.name:
             xml.set('n', self.name)
+        if self.language:
+            xml.set('xml:lang', self.language)
         for child in self.children:
             xml.append(child.xml)
         return xml
 
 
 class Edition(TextPart):
-    '''Represents and Epidoc text edition.'''
+    '''Represents an Epidoc text edition.
+
+    Set the name attribute to the CTS urn.'''
 
     def __init__(self):
         super().__init__()
@@ -113,19 +121,14 @@ class Edition(TextPart):
 
 
 class Translation(TextPart):
-    '''Represents and Epidoc text translation.'''
+    '''Represents an Epidoc text translation.
+
+    Set the name attribute to the CTS urn.
+    Set the language attribute to the language of the translation.'''
 
     def __init__(self):
         super().__init__()
         self.type = 'translation'
-        self.language = None
-
-    @property
-    def xml(self):
-        xml = super().xml
-        if self.language:
-            xml.set('xml:lang', self.language)
-        return xml
 
 
 class Line:

--- a/tei.py
+++ b/tei.py
@@ -6,7 +6,21 @@ from xml.dom.minidom import parseString
 namespace = 'http://www.tei-c.org/ns/1.0'
 
 
-class Document:
+class XMLSerializer:
+    '''Mixin for XML serialization.
+
+    Override the xml property to return an ElementTree representation
+    of the object's data. This class will provide a __str__ method
+    to serialize it in a uniform way.'''
+    xml = None
+
+    def __str__(self):
+        'Serialized XML representation as a string.'
+        serialized = ET.tostring(self.xml, encoding='unicode')
+        return parseString(serialized).toprettyxml()
+
+
+class Document(XMLSerializer):
     '''Represents a TEI document.'''
 
     def __init__(self):
@@ -14,11 +28,6 @@ class Document:
         self.parts = []
         self.language = None
         self.urn = None
-
-    def __str__(self):
-        'Serialized XML representation as a string.'
-        serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
 
     @property
     def xml(self):
@@ -39,18 +48,13 @@ class Document:
         return xml
 
 
-class Header:
+class Header(XMLSerializer):
     '''Represents a TEI Header.'''
 
     def __init__(self):
         self.title = None
         self.publication = 'Converted from ATF by atf2tei.'
         self.cdli_code = None
-
-    def __str__(self):
-        'Serialized XML representation as a string.'
-        serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
 
     @property
     def xml(self):
@@ -75,7 +79,7 @@ class Header:
         return xml
 
 
-class TextPart:
+class TextPart(XMLSerializer):
     '''Represents an Epidoc text division.
 
     Set the name attribute to book, chapter, obverse, etc.,
@@ -86,11 +90,6 @@ class TextPart:
         self.type = 'textpart'
         self.language = None
         self.children = []
-
-    def __str__(self):
-        'Serialized XML representation as a string.'
-        serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
 
     def append(self, obj):
         'Append a sub-element to the list of children.'
@@ -131,16 +130,11 @@ class Translation(TextPart):
         self.type = 'translation'
 
 
-class Line:
+class Line(XMLSerializer):
     '''Represents a line of text.'''
     def __init__(self, ref, content):
         self.ref = ref
         self.content = content
-
-    def __str__(self):
-        'Serialized XML representation as a string.'
-        serialized = ET.tostring(self.xml, encoding='unicode')
-        return parseString(serialized).toprettyxml()
 
     @property
     def xml(self):

--- a/tei.py
+++ b/tei.py
@@ -69,7 +69,7 @@ class TextPart:
 
     @property
     def xml(self):
-        'Construct an XML ElemenTree representation.'
+        'Construct an XML ElementTree representation.'
         xml = ET.Element('div')
         xml.set('type', self.type)
         if self.name:
@@ -103,8 +103,21 @@ class Translation(TextPart):
         return xml
 
 
-class Text:
-    '''Represents a TEI Text body.'''
+class Line:
+    '''Represents a line of text.'''
+    def __init__(self, ref, content):
+        self.ref = ref
+        self.content = content
 
-    def __init__(self):
-        self.type = 'edition'
+    def __str__(self):
+        'Serialized XML representation as a string.'
+        serialized = ET.tostring(self.xml, encoding='unicode')
+        return parseString(serialized).toprettyxml()
+
+    @property
+    def xml(self):
+        'Construct an XML ElementTree representation.'
+        xml = ET.Element('l')
+        xml.set('n', self.ref)
+        xml.text = self.content
+        return xml

--- a/tei.py
+++ b/tei.py
@@ -56,6 +56,7 @@ class Header(XMLSerializer):
         self.title = None
         self.publication = 'Converted from ATF by atf2tei.'
         self.cdli_code = None
+        self.encodingDesc = None
 
     @property
     def xml(self):
@@ -77,6 +78,8 @@ class Header(XMLSerializer):
             idno = ET.SubElement(title, 'idno')
             idno.set('type', 'CDLI')
             idno.text = self.cdli_code
+        if self.encodingDesc:
+            xml.append(self.encodingDesc)
         return xml
 
 

--- a/test/test_tei.py
+++ b/test/test_tei.py
@@ -36,6 +36,18 @@ def test_title():
     assert title.tag == 'title'
 
 
+def test_line():
+    'Verify line serialization.'
+    ref = '1'
+    text = 'The quick brown fox jumped over the lazy dog'
+    line = tei.Line(ref, text)
+    xml = ET.fromstring(str(line))
+    # Line doesn't set a namespace attribute so no need to qualify.
+    assert xml.tag == 'l'
+    assert xml.attrib['n'] == ref
+    assert xml.text == text
+
+
 def test_document():
     'Verify basic attributes of a document are serialized.'
     name = 'Example Text Document'


### PR DESCRIPTION
Conversion improvements on top of #4 

 - Set edition urn and language
 - Restore refsDecl
 - Remove broken logogram and determinative markup
 - Convert `sign#` to `⸢sign⸣`

With these changes we're passing most of the HookTests. Everything but the duplicate references test passes when I invoke `capitains_units.cts` manually, and that's failing because our refsDecl xpath pointers select both the transliteration and translation lines. I may have to split translations into separate files after all.

There's probably something wrong with the layout still; `hooktest` itself still hangs.