### PR TITLE
Apply double-P-number urn scheme

### DIFF
--- a/atf2cts.py
+++ b/atf2cts.py
@@ -120,20 +120,14 @@ if __name__ == '__main__':
     parse_failures = 0
     export_failures = 0
 
-    textgroup = cts.TextGroup()
-    textgroup.urn = 'urn:cts:cdli:test'
-    textgroup.name = 'Test samples converted by atf2cts'
-    data_path = os.path.join('data', textgroup.urn.split(':')[-1])
-    os.makedirs(data_path, exist_ok=True)
-    print(f'Writing textgroup to {data_path}')
-    os.makedirs(data_path, exist_ok=True)
-    textgroup.write(os.path.join(data_path, '__cts__.xml'))
+    # Relative path to place CTS file repository data.
+    data_path = 'data'
 
     for filename in sys.argv[1:]:
         print('Parsing:', filename)
         with io.open(filename, encoding='utf-8') as f:
             with futures.ProcessPoolExecutor() as exe:
-                jobs = [exe.submit(convert, atf, data_path, textgroup)
+                jobs = [exe.submit(convert, atf, data_path)
                         for atf in segmentor(f)]
                 for job in futures.as_completed(jobs):
                     s, p, e = job.result()

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -20,6 +20,9 @@ def segmentor(fp):
                 yield atf
             atf = line
             sync = True
+        elif not atf:
+            print('WARNING: skipping unrecognized line:', line.strip())
+            continue
         else:
             atf += line
     if atf and sync:

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -29,6 +29,15 @@ def segmentor(fp):
         yield atf
 
 
+def write(obj, filename):
+    '''Write a serialization object to the given filename.
+
+    Creates the parent directory if necessary.'''
+    os.makedirs(os.path.dirname(filename), exist_ok=True)
+    with io.open(filename, encoding='utf-8', mode='w') as f:
+        f.write(str(obj))
+
+
 def convert(atf, textgroup, data_path):
     '''Convert an atf string and write it out as XML.
 
@@ -63,11 +72,7 @@ def convert(atf, textgroup, data_path):
     work_path = os.path.join(data_path, urn.split('.')[-1])
 
     print('Writing', urn, doc.language, 'to', work_path)
-    os.makedirs(work_path, exist_ok=True)
-    with io.open(os.path.join(work_path, '__cts__.xml'),
-                 encoding='utf-8',
-                 mode='w') as f:
-        f.write(str(work))
+    write(work, os.path.join(work_path, '__cts__.xml'))
 
     # Set Edition urn per CTS epidoc guidelines.
     editionUrn = f'{work.workUrn}.cdli-{work.language}'
@@ -82,9 +87,7 @@ def convert(atf, textgroup, data_path):
     doc.header.encodingDesc = encodingDesc
 
     doc_filename = editionUrn.split(':')[-1] + '.xml'
-    doc_path = os.path.join(work_path, doc_filename)
-    with io.open(doc_path, encoding='utf-8', mode='w') as f:
-        f.write(str(doc))
+    write(doc, os.path.join(work_path, doc_filename))
 
     return success
 
@@ -110,10 +113,7 @@ if __name__ == '__main__':
     data_path = os.path.join('data', textgroup.urn.split(':')[-1])
     os.makedirs(data_path, exist_ok=True)
     print(f'Writing textgroup to {data_path}')
-    with io.open(os.path.join(data_path, '__cts__.xml'),
-                 encoding='utf-8',
-                 mode='w') as f:
-        f.write(str(textgroup))
+    write(textgroup, os.path.join(data_path, '__cts__.xml'))
 
     for filename in sys.argv[1:]:
         print('Parsing:', filename)

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -106,7 +106,7 @@ if __name__ == '__main__':
 
     textgroup = cts.TextGroup()
     textgroup.urn = 'urn:cts:cdli:test'
-    textgroup.name = 'atf2cts test examples'
+    textgroup.name = 'Test samples converted by atf2cts'
     data_path = os.path.join('data', textgroup.urn.split(':')[-1])
     os.makedirs(data_path, exist_ok=True)
     print(f'Writing textgroup to {data_path}')

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -29,15 +29,6 @@ def segmentor(fp):
         yield atf
 
 
-def write(obj, filename):
-    '''Write a serialization object to the given filename.
-
-    Creates the parent directory if necessary.'''
-    os.makedirs(os.path.dirname(filename), exist_ok=True)
-    with io.open(filename, encoding='utf-8', mode='w') as f:
-        f.write(str(obj))
-
-
 def convert(atf, textgroup, data_path):
     '''Convert an atf string and write it out as XML.
 
@@ -72,7 +63,8 @@ def convert(atf, textgroup, data_path):
     work_path = os.path.join(data_path, urn.split('.')[-1])
 
     print('Writing', urn, doc.language, 'to', work_path)
-    write(work, os.path.join(work_path, '__cts__.xml'))
+    os.makedirs(work_path, exist_ok=True)
+    work.write(os.path.join(work_path, '__cts__.xml'))
 
     # Set Edition urn per CTS epidoc guidelines.
     editionUrn = f'{work.workUrn}.cdli-{work.language}'
@@ -87,7 +79,7 @@ def convert(atf, textgroup, data_path):
     doc.header.encodingDesc = encodingDesc
 
     doc_filename = editionUrn.split(':')[-1] + '.xml'
-    write(doc, os.path.join(work_path, doc_filename))
+    doc.write(os.path.join(work_path, doc_filename))
 
     return success
 
@@ -113,7 +105,8 @@ if __name__ == '__main__':
     data_path = os.path.join('data', textgroup.urn.split(':')[-1])
     os.makedirs(data_path, exist_ok=True)
     print(f'Writing textgroup to {data_path}')
-    write(textgroup, os.path.join(data_path, '__cts__.xml'))
+    os.makedirs(data_path, exist_ok=True)
+    textgroup.write(os.path.join(data_path, '__cts__.xml'))
 
     for filename in sys.argv[1:]:
         print('Parsing:', filename)

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -27,35 +27,7 @@ def convert(atf_text):
     doc.header = tei.Header()
     doc.header.title = atf.text.description
     doc.header.cdli_code = atf.text.code
-    '<?xml version="1.0" encoding="UTF-8"?>'
-    encodingDesc = '''
-<encodingDesc>
-  <refsDecl n="CTS">
-    <cRefPattern n="line"
-                 matchPattern="(\\w+)\\.(\\w+)\\.(\\w+)"
-                 replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\']/tei:div[@n=\'$2\']/tei:l[@n=\'$3\'])">
-      <p>This pointer pattern extracts a specific line.</p>
-    </cRefPattern>
-    <cRefPattern n="surface"
-                 matchPattern="(\\w+)\\.(\\w+)"
-                 replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\']/tei:div[@n=\'$2\'])">
-      <p>This pointer pattern extracts an inscribed surface.</p>
-    </cRefPattern>
-    <cRefPattern n="object"
-                 matchPattern="(\\w+)"
-                 replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n=\'$1\'])">
-      <p>This pointer pattern extracts a specific artefact,
-         usually a tablet.</p>
-    </cRefPattern>
-  </refsDecl>
-</encodingDesc>
-</teiHeader>
-'''
-    urn = f'urn:cts:cdli:test.{atf.text.code}'
-    # Append n={urn} xml:lang={atf.text.language} to the text element.
-    f'<text n="{urn}"'
-    if atf.text.language:
-        f'xml:lang="{atf.text.language}"'
+
     translations = {}
     objects = [item for item in atf.text.children
                if isinstance(item, OraccObject)]

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -97,7 +97,7 @@ def convert(atf_text):
                             translations[lang].append(tr_line)
                 else:
                     # Skip unknown object type.
-                    f'<!-- {type(line).__name__}: {line} -->'
+                    f'<!-- {type(obj).__name__}: {obj} -->'
                     continue
     objects = [item for item in atf.text.children
                if isinstance(item, OraccObject)]

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -38,7 +38,11 @@ def convert(atf_text):
         edition.append(part)
         for section in item.children:
             if isinstance(section, OraccObject):
-                div = tei.TextPart(section.objecttype)
+                try:
+                    name = section.name
+                except AttributeError:
+                    name = section.objecttype
+                div = tei.TextPart(name)
                 part.append(div)
             elif isinstance(section, Translation):
                 # Handle in another pass.

--- a/atf2tei.py
+++ b/atf2tei.py
@@ -72,8 +72,8 @@ def convert(atf_text):
                 # Handle in another pass.
                 continue
             else:
-                # Skip unknown section type.
-                f'<!-- {type(section).__name__}: {section} -->'
+                print('Skipping unknown section type',
+                      type(section).__name__)
                 continue
             for obj in section.children:
                 if isinstance(obj, Line):
@@ -96,8 +96,8 @@ def convert(atf_text):
                                 translations[lang] = []
                             translations[lang].append(tr_line)
                 else:
-                    # Skip unknown object type.
-                    f'<!-- {type(obj).__name__}: {obj} -->'
+                    print('Skipping unknown section child type',
+                          type(obj).__name__)
                     continue
     objects = [item for item in atf.text.children
                if isinstance(item, OraccObject)]
@@ -121,8 +121,8 @@ def convert(atf_text):
                             line = tei.Line(obj.label, text)
                             div.append(line)
                         else:
-                            # Skip unknown object type.
-                            f'<!-- {type(line).__name__}: {line} -->\n'
+                            print('Skipping unknown section child type',
+                                  {type(obj).__name__})
                             continue
     for lang, tr_lines in translations.items():
         translation = tei.Translation()

--- a/cts.py
+++ b/cts.py
@@ -47,18 +47,22 @@ class Work(XMLSerializer):
         'Construct an XML ElementTree representation of member data.'
         xml = ET.Element('ti:work')
         xml.set('xmlns:ti', self.ns['ti'])
+        if self.groupUrn:
+            xml.set('groupUrn', self.groupUrn)
+        if self.workUrn:
+            xml.set('urn', self.workUrn)
         if self.language:
             xml.set('xml:lang', self.language)
         title = ET.SubElement(xml, 'ti:title')
         title.text = self.title
         title.set('xml:lang', 'eng')
         edition = ET.SubElement(xml, 'ti:edition')
-        if self.groupUrn:
-            xml.set('groupUrn', self.groupUrn)
         if self.workUrn:
-            xml.set('urn', self.workUrn)
             edition.set('workUrn', self.workUrn)
-            edition.set('urn', self.workUrn + '.' + self.language)
+            editionUrn = self.workUrn + '.cdli'
+            if self.language:
+                editionUrn += '-' + self.language
+            edition.set('urn', editionUrn)
         label = ET.SubElement(edition, 'ti:label')
         if self.label:
             label.text = self.label

--- a/cts.py
+++ b/cts.py
@@ -6,7 +6,7 @@ from tei import XMLSerializer
 
 
 class TextGroup(XMLSerializer):
-    '''Represents a textgroup element.'''
+    '''Represents a CTS textgroup element.'''
 
     ns = {'ti': 'http://chs.harvard.edu/xmlns/cts'}
 
@@ -30,7 +30,7 @@ class TextGroup(XMLSerializer):
 
 
 class Work(XMLSerializer):
-    '''Represents a TEI work.'''
+    '''Represents a CTS work.'''
 
     ns = {'ti': 'http://chs.harvard.edu/xmlns/cts'}
 

--- a/tei.py
+++ b/tei.py
@@ -1,5 +1,6 @@
 '''Models for generating Epidoc Text Encoding Initiative xml files.'''
 
+import io
 import xml.etree.ElementTree as ET
 from xml.dom.minidom import parseString
 
@@ -19,6 +20,11 @@ class XMLSerializer:
         serialized = ET.tostring(self.xml, encoding='unicode')
         # Run the xml through minidom to control the indent.
         return parseString(serialized).toprettyxml(indent='  ')
+
+    def write(self, filename):
+        'Write a serialized representation to the given file path.'
+        with io.open(filename, encoding='utf-8', mode='w') as f:
+            f.write(str(self))
 
 
 class Document(XMLSerializer):


### PR DESCRIPTION
Generate a separate textgroup for each atf record, rather than grouping them all under `test`. This isn't pretty, since we don't have traditional auuthor attribution we can use for groups, but it a simple way to generate the expected two-level CTS file layout.

Includes a few other cleanups.