### PR TITLE
Add tei2atf script

### DIFF
--- a/tei2atf.py
+++ b/tei2atf.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+
+'''Convert a TEI XML document in the ATF.
+
+Used by the Cuneiform Digital Library Initiative.
+'''
+
+import io
+import sys
+import xml.etree.ElementTree as ET
+
+import tei
+
+
+def convert(fp):
+    'Read TEI XML from the given file-like object and return ATF.'
+    xml = ET.fromstring(fp.read())
+    ns = {
+        'tei': tei.namespace,
+        'xml': 'http://www.w3.org/XML/1998/namespace',
+    }
+    print(xml.find('tei:text', ns))
+
+    # Collection of lines for output.
+    atf = []
+
+    # Fetch data for the header.
+    title = xml.find('./tei:teiHeader//tei:title', ns).text
+    code = xml.find('./tei:teiHeader//tei:idno', ns).text
+    edition = xml.find('./tei:text//tei:div[@type="edition"]', ns)
+    language = edition.get(f'{{{ns["xml"]}}}lang')
+
+    # Construct the header.
+    atf.append(f'&{code} = {title}')
+    atf.append(f'#atf: lang {language}')
+
+    # Loop over parts adding labels.
+    for obj in edition.findall('tei:div', ns):
+        print(obj.tag)
+        atf.append('@' + obj.get('n'))
+        for surface in obj.findall('tei:div', ns):
+            print(surface.tag)
+            atf.append('@' + surface.get('n'))
+            for line in surface.findall('tei:l', ns):
+                print(line.tag)
+                atf.append(f'{line.get("n")}. {line.text}')
+
+    # Return the ATF result as a string.
+    return '\n'.join(atf)
+
+
+if __name__ == '__main__':
+    for name in sys.argv[1:]:
+        with io.open(name, encoding='utf-8') as f:
+            atf = convert(f)
+            print(atf)

--- a/tei2atf.py
+++ b/tei2atf.py
@@ -37,7 +37,7 @@ def convert(fp):
     urn = edition.get('n')
 
     # Construct the header.
-    if idno:
+    if idno is not None:
         # Get the CDLI number from the teiHeader.
         code = idno.text
     else:

--- a/tei2atf.py
+++ b/tei2atf.py
@@ -19,30 +19,33 @@ def convert(fp):
         'tei': tei.namespace,
         'xml': 'http://www.w3.org/XML/1998/namespace',
     }
-    print(xml.find('tei:text', ns))
 
     # Collection of lines for output.
     atf = []
 
     # Fetch data for the header.
     title = xml.find('./tei:teiHeader//tei:title', ns).text
-    code = xml.find('./tei:teiHeader//tei:idno', ns).text
+    idno = xml.find('./tei:teiHeader//tei:idno', ns)
     edition = xml.find('./tei:text//tei:div[@type="edition"]', ns)
     language = edition.get(f'{{{ns["xml"]}}}lang')
+    urn = edition.get('n')
 
     # Construct the header.
+    if idno:
+        # Get the CDLI number from the teiHeader.
+        code = idno.text
+    else:
+        # No CDLI number, use part of the urn instead.
+        code = ':'.join(urn.split(':')[2:])
     atf.append(f'&{code} = {title}')
     atf.append(f'#atf: lang {language}')
 
     # Loop over parts adding labels.
     for obj in edition.findall('tei:div', ns):
-        print(obj.tag)
         atf.append('@' + obj.get('n'))
         for surface in obj.findall('tei:div', ns):
-            print(surface.tag)
             atf.append('@' + surface.get('n'))
             for line in surface.findall('tei:l', ns):
-                print(line.tag)
                 atf.append(f'{line.get("n")}. {line.text}')
 
     # Return the ATF result as a string.

--- a/test/iliad.xml
+++ b/test/iliad.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?xml-model href="http://www.stoa.org/epidoc/schema/8.19/tei-epidoc.rng"
+  schematypens="http://relaxng.org/ns/structure/1.0"?>
+<TEI xmlns="http://www.tei-c.org/ns/1.0">
+    <teiHeader>
+        <fileDesc>
+            <titleStmt>
+                <title>Iliad (Greek). Machine readable text</title>
+                <author>Homer</author>
+                <sponsor>Perseus Project, Tufts University</sponsor>
+                <funder n="org:AnnCPB">The Annenberg CPB/Project</funder>
+            </titleStmt>
+            <publicationStmt>
+                <publisher>Trustees of Tufts University</publisher>
+                <pubPlace>Medford, MA</pubPlace>
+                <authority>Perseus Project</authority>
+            </publicationStmt>
+            <sourceDesc>
+                <biblStruct>
+                    <monogr>
+                        <author>Homer</author>
+                        <title>Iliadis (Iliad) in two volumes. David B. Monro and Thomas W. Allen, eds. Editio Tertia (Third Edition).</title>
+                        <imprint>
+                            <publisher>Oxford, Oxford University Press</publisher>
+                            <date>1920</date>
+                        </imprint>
+                    </monogr>
+                    <ref target="https://archive.org/details/homerioperarecog01homeuoft">Internet
+                        Archive</ref>
+                    <ref target="https://archive.org/details/homerioperarecog02homeuoft">Internet
+                        Archive</ref>
+                </biblStruct>
+            </sourceDesc>
+        </fileDesc>
+        <encodingDesc>
+            <refsDecl n="CTS">
+                <cRefPattern n="line" matchPattern="(\w+).(\w+)"
+                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1']//tei:l[@n='$2'])">
+                    <p>This pointer pattern extracts Book and Line</p>
+                </cRefPattern>
+                <cRefPattern n="book" matchPattern="(\w+)"
+                    replacementPattern="#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div[@n='$1'])">
+                    <p>This pointer pattern extracts Book</p>
+                </cRefPattern>
+            </refsDecl>
+            <refsDecl>
+                <refState delim="." unit="book"/>
+                <refState unit="line"/>
+            </refsDecl>
+        </encodingDesc>
+        <revisionDesc>
+            <change who="Ralph Giles" when="2019-07-29">Trimmed to one paragraph to make a test document.</change>
+        </revisionDesc>
+    </teiHeader>
+    <text xml:lang="grc">
+        <body>
+            <div type="edition" n="urn:cts:greekLit:tlg0012.tlg001.perseus-grc2" xml:lang="grc">
+                <div type="textpart" subtype="Book" n="1">
+                    <milestone ed="p" n="1" unit="card"/>
+                    <l n="1">
+                        <milestone ed="P" unit="para"/>μῆνιν ἄειδε θεὰ Πηληϊάδεω Ἀχιλῆος</l>
+                    <l n="2">οὐλομένην, ἣ μυρίʼ Ἀχαιοῖς ἄλγεʼ ἔθηκε,</l>
+                    <l n="3">πολλὰς δʼ ἰφθίμους ψυχὰς Ἄϊδι προΐαψεν</l>
+                    <l n="4">ἡρώων, αὐτοὺς δὲ ἑλώρια τεῦχε κύνεσσιν</l>
+                    <l n="5">οἰωνοῖσί τε πᾶσι, Διὸς δʼ ἐτελείετο βουλή,</l>
+                    <l n="6">ἐξ οὗ δὴ τὰ πρῶτα διαστήτην ἐρίσαντε</l>
+                    <l n="7">Ἀτρεΐδης τε ἄναξ ἀνδρῶν καὶ δῖος Ἀχιλλεύς.</l>
+                </div>
+            </div>
+        </body>
+    </text>
+</TEI>

--- a/test/test_tei2atf.py
+++ b/test/test_tei2atf.py
@@ -1,0 +1,32 @@
+import io
+
+import tei2atf
+import atf2tei
+
+
+atf_filename = 'SIL-034.atf'
+iliad = 'test/iliad.xml'
+
+
+def test_roundtrip():
+    '''Verify round-trip conversion to and from XML.'''
+    with io.open(atf_filename, encoding='utf-8') as f:
+        atf_sample = f.read()
+
+    xml = atf2tei.convert(atf_sample)
+    assert xml
+    atf = tei2atf.convert(io.StringIO(str(xml)))
+    assert atf
+    xml = atf2tei.convert(atf)
+    assert xml
+
+
+def test_iliad():
+    '''Verify conversion of an Iliad fragment.'''
+    with io.open(iliad, encoding='utf-8') as f:
+        atf = tei2atf.convert(f)
+        assert atf
+        assert atf.startswith('&greekLit:tlg0012.tlg001')
+        assert 'lang grc' in atf
+        assert '@Book 1' in atf
+        assert '1. μῆνιν ἄειδε θεὰ' in atf


### PR DESCRIPTION
Quick script to make the reverse conversion: TEI XML -> ATF.

Useful for testing and importing documents other projects have published.