### PR TITLE
Write out separate files for translations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 pytest = "*"
 pycodestyle = "*"
+hooktest = "*"
 
 [packages]
 pyoracc = "~=0.1"

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -114,8 +114,6 @@ if __name__ == '__main__':
     from datetime import datetime
 
     start = datetime.utcnow()
-    failed_parse = []
-    failed_export = []
     successful = 0
     parse_failures = 0
     export_failures = 0

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -14,7 +14,7 @@ def segmentor(fp):
     sync = False
     for line in fp.readlines():
         if line.startswith('&'):
-            print('New atf record: ', line.strip())
+            print('New atf record:', line.strip())
             # Start of a new record. Flush the old one, if any.
             if atf and sync:
                 yield atf

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -56,7 +56,6 @@ def convert(atf, data_path, textgroup=None):
         _ = parseString(str(doc))
     except Exception as e:
         print('Error parsing converted XML:', e)
-        print(doc)
         return export_failed
 
     if not textgroup:

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import os
 import xml.etree.ElementTree as ET
 from xml.dom.minidom import parseString
 
@@ -106,7 +107,6 @@ def convert(atf, data_path, textgroup=None):
 
 if __name__ == '__main__':
     import io
-    import os
     import sys
 
     from concurrent import futures

--- a/atf2cts.py
+++ b/atf2cts.py
@@ -136,7 +136,7 @@ if __name__ == '__main__':
                     export_failures += e
     if parse_failures:
         print('Error:', parse_failures, 'records did not convert.')
-    if failed_export:
+    if export_failures:
         print('Error:', export_failures, 'records did not serialize.')
     elapsed = datetime.utcnow() - start
     seconds = elapsed.seconds + elapsed.microseconds*1e-6

--- a/cts.py
+++ b/cts.py
@@ -39,8 +39,7 @@ class Work(XMLSerializer):
         self.workUrn = None
         self.language = None
         self.title = None
-        self.label = None
-        self.description = None
+        self.parts = []
 
     @property
     def xml(self):
@@ -56,21 +55,31 @@ class Work(XMLSerializer):
         title = ET.SubElement(xml, 'ti:title')
         title.text = self.title
         title.set('xml:lang', 'eng')
-        edition = ET.SubElement(xml, 'ti:edition')
-        if self.workUrn:
-            edition.set('workUrn', self.workUrn)
-            editionUrn = self.workUrn + '.cdli'
-            if self.language:
-                editionUrn += '-' + self.language
-            edition.set('urn', editionUrn)
-        label = ET.SubElement(edition, 'ti:label')
-        if self.label:
-            label.text = self.label
-            label.set('xml:lang', 'eng')
-        description = ET.SubElement(edition, 'ti:description')
-        if self.description:
-            description.text = self.description
-            description.set('xml:lang', 'eng')
+
+        for part in self.parts:
+            if part.type == 'edition':
+                textElement = ET.SubElement(xml, 'ti:edition')
+                # ti:edition inherits the language of the ti:work element.
+            elif part.type == 'translation':
+                textElement = ET.SubElement(xml, 'ti:translation')
+                # Translations have their own languages.
+                textElement.set('xml:lang', part.language)
+
+            if self.workUrn:
+                textElement.set('workUrn', self.workUrn)
+                urn = self.workUrn + '.cdli'
+                if part.language:
+                    urn += '-' + part.language
+                textElement.set('urn', urn)
+
+            labelElement = ET.SubElement(textElement, 'ti:label')
+            labelElement.text = part.label
+            labelElement.set('xml:lang', 'mul')
+
+            descriptionElement = ET.SubElement(textElement, 'ti:description')
+            descriptionElement.text = part.description
+            descriptionElement.set('xml:lang', 'eng')
+
         return xml
 
 

--- a/cts.py
+++ b/cts.py
@@ -79,21 +79,16 @@ class RefsDecl(XMLSerializer):
 
     Results are specific to the way we structure cuneiform
     data from ATF.'''
-    prefix = '#xpath(/tei:TEI/tei:text/tei:body/tei:div'
+    prefix = '#xpath(/tei:TEI/tei:text/tei:body/tei:div/tei:div'
     levels = [
         (
-          'line', 3,
+          'line', 2,
           'This pattern references a specific line.',
-          prefix + "/tei:div[@n='$1']/tei:div[@n='$2']/tei:l[@n='$3'])"
+          prefix + "/tei:div[@n='$1']/tei:l[@n='$2'])"
         ),
         (
-          'surface', 2,
-          'This pattern references an inscribed surface.',
-          prefix + "/tei:div[@n='$1']/tei:div[@n='$2'])"
-        ),
-        (
-          'object', 1,
-          'This pattern references a specific artefact, usually a tablet.',
+          'surface', 1,
+          'This pattern references an inscribed surface on an object.',
           prefix + "/tei:div[@n='$1'])"
         ),
     ]

--- a/tei.py
+++ b/tei.py
@@ -94,6 +94,9 @@ class TextPart(XMLSerializer):
         self.type = 'textpart'
         self.language = None
         self.children = []
+        # Attributes for CTS metadata.
+        self.label = None
+        self.description = None
 
     def append(self, obj):
         'Append a sub-element to the list of children.'

--- a/test/test_atf2tei.py
+++ b/test/test_atf2tei.py
@@ -13,8 +13,9 @@ test_filename = 'SIL-034.atf'
 def test_convert():
     '''Verify conversion of a test file.'''
     with io.open(test_filename, encoding='utf-8') as f:
-        xml = atf2tei.convert(f.read())
-        assert xml
+        doc = atf2tei.convert(f.read())
+        assert doc
+        assert len(doc.parts) == 1
 
 
 def test_segmentor_single():


### PR DESCRIPTION
To align with CTS guidelines, write out each primary edition and its translations in separate files. This is primarily necessary so the `<refsDecl>` element can provide xpath queries returning unique passages for a given reference.